### PR TITLE
Add RTD docs monitoring

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -92,6 +92,10 @@ sites:
     url: https://microstack.run
   - name: netplan.io
     url: https://netplan.io
+  - name: Pro Client docs
+    url: https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/
+  - name: cloud-init docs
+    url: https://canonical-cloud-init.readthedocs-hosted.com/en/latest/
 
 status-website:
   baseUrl: /upptime

--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -92,10 +92,8 @@ sites:
     url: https://microstack.run
   - name: netplan.io
     url: https://netplan.io
-  - name: Pro Client docs
-    url: https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/
-  - name: cloud-init docs
-    url: https://canonical-cloud-init.readthedocs-hosted.com/en/latest/
+  - name: readthedocs docs
+    url: https://documentation.ubuntu.com
 
 status-website:
   baseUrl: /upptime


### PR DESCRIPTION
With multiple sets of documentation now hosted on 
readthedocs (RTD), we would like to have visibility into the 
reliability of the service. Now that all RTD docs will 
eventually be served with the custom domain of 
"documentation.ubuntu.com" we would like to add this domain
to upptime.